### PR TITLE
Docker media support for Django

### DIFF
--- a/compose/production/django/Dockerfile
+++ b/compose/production/django/Dockerfile
@@ -39,8 +39,9 @@ RUN chmod +x /start
 RUN chown django /start
 COPY --from=client-builder /app /app
 
-# We should make this dir before mounting with docker-compose, so the owner will be django
+# We should make this dirs before mounting with docker-compose, so the owner will be django
 RUN mkdir /app/staticfiles
+RUN mkdir -p /app/chitweb/media
 
 RUN chown -R django /app
 

--- a/local.yml
+++ b/local.yml
@@ -3,6 +3,7 @@ version: '3'
 volumes:
   local_postgres_data: {}
   local_postgres_data_backups: {}
+  media: {}
 
 services:
   django:
@@ -14,6 +15,7 @@ services:
       - postgres
     volumes:
       - .:/app
+      - media:/app/media
     env_file:
       - ./.envs/.local/.django
       - ./.envs/.local/.postgres

--- a/local.yml
+++ b/local.yml
@@ -15,7 +15,7 @@ services:
       - postgres
     volumes:
       - .:/app
-      - media:/app/media
+      - media:/app/chitweb/media
     env_file:
       - ./.envs/.local/.django
       - ./.envs/.local/.postgres

--- a/production.yml
+++ b/production.yml
@@ -18,7 +18,7 @@ services:
       - redis
     volumes:
       - shared_static:/app/staticfiles
-      - media:/app/media
+      - media:/app/chitweb/media
     env_file:
       - ./.envs/.production/.django
       - ./.envs/.production/.postgres

--- a/production.yml
+++ b/production.yml
@@ -4,6 +4,7 @@ volumes:
   production_postgres_data: {}
   production_postgres_data_backups: {}
   shared_static: {}
+  media: {}
 
 services:
   django:
@@ -17,6 +18,7 @@ services:
       - redis
     volumes:
       - shared_static:/app/staticfiles
+      - media:/app/media
     env_file:
       - ./.envs/.production/.django
       - ./.envs/.production/.postgres


### PR DESCRIPTION
Цхьа пал бу шуна, хIара болх беш ца хилахь сан бехк бац.
Короче:
- Django нужна папка media в недрах chitweb, создал отдельный volume в docker-compose для этого дела
- mkdir запускается в dockerfile, потому что, если его заранее не создать, там нужные права не присваиваются, в общем аналогично с staticfiles